### PR TITLE
Add hotkey to resend last user message

### DIFF
--- a/src/application/ui.rs
+++ b/src/application/ui.rs
@@ -169,6 +169,20 @@ async fn start_loop<B: Backend>(
                 break;
             }
             Input {
+                key: Key::Char('r'),
+                ctrl: true,
+                ..
+            } => {
+                let last_message = app_state
+                    .messages
+                    .iter()
+                    .filter(|message| message.author == Author::User)
+                    .last();
+                if let Some(message) = last_message.cloned() {
+                    send_user_message!(&message.text);
+                }
+            }
+            Input {
                 key: Key::Enter, ..
             } => {
                 let input_str = &textarea.lines().join("\n");

--- a/src/application/ui.rs
+++ b/src/application/ui.rs
@@ -176,7 +176,7 @@ async fn start_loop<B: Backend>(
                 let last_message = app_state
                     .messages
                     .iter()
-                    .filter(|message| message.author == Author::User)
+                    .filter(|message| return message.author == Author::User)
                     .last();
                 if let Some(message) = last_message.cloned() {
                     send_user_message!(&message.text);


### PR DESCRIPTION
Adds one of the features of #1:
- Press `Ctrl+R` to repeat the previous prompt

I couldn't figure out how to stop current response, as I am not familiar with `tokio::sync`.

The code was extracted to a local macro to reduce duplication.
Hope this helps :)