### PR TITLE
Allow standard-ish environment variables for OpenAI.

### DIFF
--- a/src/application/cli.rs
+++ b/src/application/cli.rs
@@ -153,6 +153,7 @@ fn arg_model() -> Arg {
         .short('m')
         .long("model")
         .env("OATMEAL_MODEL")
+        .env("OPENAI_MODEL")
         .num_args(1)
         .help("The initial model on a backend to consume")
         .default_value("llama2:latest");
@@ -271,6 +272,8 @@ fn build() -> Command {
             Arg::new("openai-token")
                 .long("openai-token")
                 .env("OATMEAL_OPENAI_TOKEN")
+                .env("OPENAI_API_KEY")
+                .env("OPENAI_KEY")
                 .num_args(1)
                 .help("OpenAI API token when using the OpenAI backend")
                 .global(true),


### PR DESCRIPTION
Many applications require these to be set, no need in creating more environment variables just for Oatmeal.