### PR TITLE
update cargo install command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ scoop install oatmeal
 ### Cargo
 
 ```sh
-cargo install oatmeal
+cargo install oatmeal --locked
 ```
 
 ### Manual


### PR DESCRIPTION
For me it was trying to link to multiple versions of ratatui and failed to compile. Adding `--locked` forces cargo to use the exact versions listed and avoids these kind of errors.