### PR TITLE
fix: Use xdg config dirs by default

### DIFF
--- a/src/configuration/config.rs
+++ b/src/configuration/config.rs
@@ -68,7 +68,12 @@ impl Config {
         let default_editor = EditorName::Clipboard.to_string();
 
         #[cfg(not(target_os = "macos"))]
-        let config_path = dirs::cache_dir().unwrap().join("oatmeal/config.toml");
+        let mut config_path = dirs::cache_dir().unwrap().join("oatmeal/config.toml");
+        if !config_path.exists() {
+            config_path = dirs::config_local_dir()
+                .unwrap()
+                .join("oatmeal/config.toml");
+        }
         #[cfg(target_os = "macos")]
         let config_path =
             path::PathBuf::from(env::var("HOME").unwrap()).join(".config/oatmeal/config.toml");


### PR DESCRIPTION
Fixes #45 

cache dir path is used for backwards compatibility.