### PR TITLE
feat: `ctrl + o` to insert a line break

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ CHAT HOTKEYS:
   - CTRL+U - Page up.
   - CTRL+D - Page down.
   - CTRL+C - Interrupt waiting for prompt response if in progress, otherwise exit.
+  - CTRL+O - Insert a line break at the cursor position.
   - CTRL+R - Resubmit your last message to the backend.
 
 CHAT CODE ACTIONS:

--- a/src/application/ui.rs
+++ b/src/application/ui.rs
@@ -187,6 +187,13 @@ async fn start_loop<B: Backend>(
                     break;
                 }
             }
+            Event::KeyboardCTRLO() => {
+                if app_state.waiting_for_backend {
+                    continue;
+                }
+                app_state.exit_warning = false;
+                textarea.insert_newline();
+            }
             Event::KeyboardCTRLR() => {
                 let last_message = app_state
                     .messages

--- a/src/domain/models/event.rs
+++ b/src/domain/models/event.rs
@@ -8,6 +8,7 @@ pub enum Event {
     BackendPromptResponse(BackendResponse),
     KeyboardCharInput(Input),
     KeyboardCTRLC(),
+    KeyboardCTRLO(),
     KeyboardCTRLR(),
     KeyboardEnter(),
     KeyboardPaste(String),

--- a/src/domain/services/actions.rs
+++ b/src/domain/services/actions.rs
@@ -37,6 +37,7 @@ HOTKEYS:
 - CTRL+U - Page up.
 - CTRL+D - Page down.
 - CTRL+C - Interrupt waiting for prompt response if in progress, otherwise exit.
+- CTRL+O - Insert a line break at the cursor position.
 - CTRL+R - Resubmit your last message to the backend.
 
 CODE ACTIONS:

--- a/src/domain/services/events.rs
+++ b/src/domain/services/events.rs
@@ -93,6 +93,13 @@ impl EventsService {
                         return Some(Event::KeyboardCTRLC());
                     }
                     Input {
+                        key: Key::Char('o'),
+                        ctrl: true,
+                        ..
+                    } => {
+                        return Some(Event::KeyboardCTRLO());
+                    }
+                    Input {
                         key: Key::Char('r'),
                         ctrl: true,
                         ..


### PR DESCRIPTION
I’v been using oatmeal for the past several days and have found it  to be quite beneficial. However, I believe that the chat functionality could be improved  by allowing the insertion of line breaks.

My intention was to configure a key binding using Shift + Enter to insert a line break, but unfortunately, the application does not seem to recognize this.

Additionally, I've tried setting Ctrl + M and Ctrl + Enter as potential key bindings, but these too aren't detected as intended. Instead, the application appeared to recognize them as a simple Enter key press, which results in the message being sent.(Possibly, this could be due to the specifications of tui-textarea...?)

Thank you for considering this enhancement.