### PR TITLE
feat: New feature: Edit Prompt in editor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ syntect = { version = "=5.1.0", default-features = false, features = [
   "plist-load",
   "regex-onig"
 ] }
+tempfile = "3"
 tokio = { version = "=1.33.0", features = ["fs", "macros", "rt-multi-thread", "sync", "process"] }
 tokio-util = "=0.7.9"
 toml_edit = "=0.21.0"

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ CHAT COMMANDS:
   - /append (/a) [CODE_BLOCK_NUMBER?] - Appends code blocks to an editor. See Code Actions for more details.
   - /replace (/r) [CODE_BLOCK_NUMBER?] - Replaces selections with code blocks in an editor. See Code Actions for more details.
   - /copy (/c) [CODE_BLOCK_NUMBER?] - Copies the entire chat history to your clipboard. When a `CODE_BLOCK_NUMBER` is used, only the specified copy blocks are copied to clipboard. See Code Actions for more details.
+  - /edit (/e) - Opens the prompt in an editor.
   - /quit /exit (/q) - Exit Oatmeal.
   - /help (/h) - Provides this help menu.
 

--- a/src/domain/models/action.rs
+++ b/src/domain/models/action.rs
@@ -8,4 +8,5 @@ pub enum Action {
     BackendAbort(),
     BackendRequest(BackendPrompt),
     CopyMessages(Vec<Message>),
+    EditPromptBegin(),
 }

--- a/src/domain/models/author.rs
+++ b/src/domain/models/author.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -11,12 +13,13 @@ pub enum Author {
     Model,
 }
 
-impl ToString for Author {
-    fn to_string(&self) -> String {
-        match self {
-            Author::User => return Config::get(ConfigKey::Username),
-            Author::Oatmeal => return String::from("Oatmeal"),
-            Author::Model => return Config::get(ConfigKey::Model),
-        }
+impl fmt::Display for Author {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Author::User => Config::get(ConfigKey::Username),
+            Author::Oatmeal => String::from("Oatmeal"),
+            Author::Model => Config::get(ConfigKey::Model),
+        };
+        return write!(f, "{}", name);
     }
 }

--- a/src/domain/models/editor.rs
+++ b/src/domain/models/editor.rs
@@ -100,6 +100,21 @@ pub trait Editor {
         codeblock: String,
         accept_type: AcceptType,
     ) -> Result<()>;
+
+    /// Opens the prompt in the editor.
+    /// Default implementation:
+    ///     - Uses the $EDITOR environment variable to get the executable and launches that in a
+    ///     new process.
+    ///     - Blocks the thread.
+    #[allow(clippy::implicit_return)]
+    async fn edit_prompt(&self, temp_file_path: &std::path::Path) -> Result<()> {
+        let editor = std::env::var("EDITOR")?;
+        let _status = std::process::Command::new(editor)
+            .arg(temp_file_path)
+            // Blocking method
+            .status()?;
+        return Ok(());
+    }
 }
 
 pub type EditorBox = Box<dyn Editor + Send + Sync>;

--- a/src/domain/models/event.rs
+++ b/src/domain/models/event.rs
@@ -1,3 +1,4 @@
+use tokio::sync::mpsc::UnboundedSender;
 use tui_textarea::Input;
 
 use super::BackendResponse;
@@ -6,8 +7,12 @@ use super::Message;
 pub enum Event {
     BackendMessage(Message),
     BackendPromptResponse(BackendResponse),
+    EditPrompt(UnboundedSender<Event>),
+    EditPromptMessage(Message),
+    NewPrompt(String),
     KeyboardCharInput(Input),
     KeyboardCTRLC(),
+    KeyboardCTRLE(),
     KeyboardCTRLO(),
     KeyboardCTRLR(),
     KeyboardEnter(),

--- a/src/domain/models/message.rs
+++ b/src/domain/models/message.rs
@@ -12,7 +12,7 @@ pub enum MessageType {
     Error,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Message {
     pub author: Author,
     pub text: String,

--- a/src/domain/models/slash_commands.rs
+++ b/src/domain/models/slash_commands.rs
@@ -29,6 +29,7 @@ impl SlashCommand {
             || cmd.is_copy_code_block()
             || cmd.is_copy_chat()
             || cmd.is_help()
+            || cmd.is_edit_prompt()
         {
             return Some(cmd);
         }
@@ -66,5 +67,8 @@ impl SlashCommand {
 
     pub fn is_help(&self) -> bool {
         return ["/h", "/help"].contains(&self.command.as_str());
+    }
+    pub fn is_edit_prompt(&self) -> bool {
+        return ["/e", "/edit"].contains(&self.command.as_str());
     }
 }

--- a/src/domain/models/slash_commands_test.rs
+++ b/src/domain/models/slash_commands_test.rs
@@ -165,3 +165,28 @@ fn it_is_not_copy_code() {
     let cmd = SlashCommand::parse("/copy").unwrap();
     assert!(!cmd.is_copy_code_block());
 }
+#[test]
+fn it_is_edit_prompt() {
+    let cmd = SlashCommand::parse("/edit").unwrap();
+    assert!(cmd.is_edit_prompt());
+}
+#[test]
+fn it_is_short_edit_prompt() {
+    let cmd = SlashCommand::parse("/e").unwrap();
+    assert!(cmd.is_edit_prompt());
+}
+#[test]
+fn it_is_not_edit_prompt() {
+    let cmd = SlashCommand::parse("/ml").unwrap();
+    assert!(!cmd.is_edit_prompt());
+}
+#[test]
+fn it_is_edit_prompt_with_text() {
+    let cmd = SlashCommand::parse("/edit some text").unwrap();
+    assert!(cmd.is_edit_prompt());
+}
+#[test]
+fn it_is_short_edit_prompt_with_text() {
+    let cmd = SlashCommand::parse("/e some text").unwrap();
+    assert!(cmd.is_edit_prompt());
+}

--- a/src/domain/services/actions.rs
+++ b/src/domain/services/actions.rs
@@ -28,6 +28,7 @@ COMMANDS:
 - /append (/a) [CODE_BLOCK_NUMBER?] - Appends code blocks to an editor. See Code Actions for more details.
 - /replace (/r) [CODE_BLOCK_NUMBER?] - Replaces selections with code blocks in an editor. See Code Actions for more details.
 - /copy (/c) [CODE_BLOCK_NUMBER?] - Copies the entire chat history to your clipboard. When a `CODE_BLOCK_NUMBER` is used, only the specified copy blocks are copied to clipboard. See Code Actions for more details.
+- /edit (/e) - Opens the prompt in an editor.
 - /quit /exit (/q) - Exit Oatmeal.
 - /help (/h) - Provides this help menu.
 
@@ -156,7 +157,7 @@ async fn accept_codeblock(
             tx.send(Event::BackendMessage(Message::new_with_type(
                 Author::Oatmeal,
                 MessageType::Error,
-                &format!("Failed to commuicate with editor:\n\n{err}"),
+                &format!("Failed to communicate with editor:\n\n{err}"),
             )))?;
         }
     }
@@ -177,7 +178,7 @@ fn copy_messages(messages: Vec<Message>, tx: &mpsc::UnboundedSender<Event>) -> R
         payload = messages
             .iter()
             .map(|message| {
-                return format!("{}: {}", message.author.to_string(), message.text);
+                return format!("{}: {}", message.author, message.text);
             })
             .collect::<Vec<String>>()
             .join("\n\n");
@@ -289,6 +290,9 @@ impl ActionsService {
                         }
                         return Ok(());
                     });
+                }
+                Action::EditPromptBegin() => {
+                    tx.send(Event::EditPrompt(tx.clone()))?;
                 }
             }
         }

--- a/src/domain/services/app_state.rs
+++ b/src/domain/services/app_state.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 use ratatui::prelude::Rect;
 use tokio::sync::mpsc;
 
+use super::edit_prompt;
 use super::BubbleList;
 use super::CodeBlocks;
 use super::Scroll;
@@ -48,6 +49,7 @@ pub struct AppState<'a> {
     pub session_id: String,
     pub sessions_service: Sessions,
     pub waiting_for_backend: bool,
+    pub edit_prompt_service: Option<edit_prompt::ActiveService>,
 }
 
 impl<'a> AppState<'a> {
@@ -76,6 +78,7 @@ impl<'a> AppState<'a> {
             session_id: Sessions::create_id(),
             sessions_service: props.sessions_service,
             waiting_for_backend: false,
+            edit_prompt_service: None,
         };
 
         let backend_name = props.backend.name();
@@ -133,6 +136,7 @@ impl<'a> AppState<'a> {
             session_id,
             sessions_service: props.sessions_service,
             waiting_for_backend: false,
+            edit_prompt_service: None,
         };
 
         app_state
@@ -269,6 +273,11 @@ impl<'a> AppState<'a> {
             // Reset backend context on model switch.
             if command.is_model_set() {
                 self.backend_context = "".to_string();
+            }
+
+            if command.is_edit_prompt() {
+                tx.send(Action::EditPromptBegin())?;
+                should_continue = true;
             }
         }
 

--- a/src/domain/services/app_state_test.rs
+++ b/src/domain/services/app_state_test.rs
@@ -38,6 +38,7 @@ impl Default for AppState<'static> {
             scroll: Scroll::default(),
             sessions_service: Sessions::default(),
             waiting_for_backend: false,
+            edit_prompt_service: None,
         };
     }
 }

--- a/src/domain/services/edit_prompt.rs
+++ b/src/domain/services/edit_prompt.rs
@@ -1,0 +1,279 @@
+use anyhow::Result;
+
+use itertools::Itertools as _;
+use std::io::{BufRead as _, BufReader, Seek as _, Write as _};
+
+use crate::domain::models::{Event, Message};
+
+#[cfg(test)]
+#[path = "edit_prompt_test.rs"]
+mod tests;
+
+pub type ActiveService = TypestateService<Parseable>;
+
+pub trait State {}
+pub struct TypestateService<S: State> {
+    state: S,
+}
+
+type EventTx = tokio::sync::mpsc::UnboundedSender<Event>;
+
+pub struct Buildable {}
+pub struct Startable<'a> {
+    event_tx: EventTx,
+    prompt: &'a str,
+    messages: &'a [Message],
+}
+pub struct Launchable {
+    event_tx: EventTx,
+    temp_file: tempfile::NamedTempFile,
+    original_prompt: String,
+}
+pub struct Parseable {
+    event_tx: EventTx,
+    temp_file: tempfile::NamedTempFile,
+    original_prompt: String,
+}
+
+impl State for Buildable {}
+impl State for Startable<'_> {}
+impl State for Launchable {}
+impl State for Parseable {}
+
+impl<S> TypestateService<S>
+where
+    S: State,
+{
+    pub fn build() -> TypestateService<Buildable> {
+        return TypestateService {
+            state: Buildable {},
+        };
+    }
+}
+
+impl TypestateService<Buildable> {
+    pub fn event_tx(self, event_tx: &EventTx) -> TypestateService<Startable<'_>> {
+        return TypestateService {
+            state: Startable {
+                event_tx: event_tx.clone(),
+                prompt: "",
+                messages: &[],
+            },
+        };
+    }
+}
+
+impl<'a> TypestateService<Startable<'a>> {
+    pub fn prompt(self, prompt: &'a str) -> TypestateService<Startable<'a>> {
+        return TypestateService {
+            state: Startable {
+                prompt,
+                ..self.state
+            },
+        };
+    }
+
+    pub fn messages(self, messages: &'a [Message]) -> TypestateService<Startable<'a>> {
+        return TypestateService {
+            state: Startable {
+                messages,
+                ..self.state
+            },
+        };
+    }
+
+    fn create_temp_file(self) -> Result<TypestateService<Launchable>> {
+        let Startable {
+            event_tx,
+            prompt,
+            messages,
+        } = self.state;
+
+        let temp_file = create_temp_file(prompt, messages)?;
+
+        return Ok(TypestateService {
+            state: Launchable {
+                event_tx,
+                original_prompt: prompt.to_owned(),
+                temp_file,
+            },
+        });
+    }
+
+    pub async fn start(self) -> Option<TypestateService<Parseable>> {
+        let event_tx = &self.state.event_tx.clone();
+        let launchable = match self.create_temp_file() {
+            Ok(new_service) => new_service,
+            Err(err) => {
+                let _ = send_error(event_tx, &err, "could not create temp file");
+                return None;
+            }
+        };
+        let parseable = match launchable.launch().await {
+            Ok(new_service) => new_service,
+            Err(err) => {
+                let _ = send_error(event_tx, &err, "could not launch editor");
+                return None;
+            }
+        };
+        // try to read the file once
+        let maybe_parseable = match parseable.parse() {
+            Ok(opt_service) => opt_service,
+            Err(err) => {
+                let _ = send_error(event_tx, &err, "could not parse prompt file");
+                return None;
+            }
+        };
+
+        return maybe_parseable;
+    }
+}
+
+impl TypestateService<Launchable> {
+    async fn launch(self) -> Result<TypestateService<Parseable>> {
+        let Launchable {
+            event_tx,
+            temp_file,
+            original_prompt,
+        } = self.state;
+
+        // Blocking here until the editor process returns. The process will return when the user
+        // closes a terminal editor, but it will also return after the initial launch of a
+        // gui text editor (e.g. vscode). Therefore, we cannot assume that the user has
+        // finished editing the prompt just because the editor process has returned.
+        let temp_file_path = temp_file.path().to_owned();
+        launch_editor(&temp_file_path).await?;
+
+        return Ok(TypestateService {
+            state: Parseable {
+                event_tx,
+                temp_file,
+                original_prompt,
+            },
+        });
+    }
+}
+
+impl TypestateService<Parseable> {
+    fn parse(self) -> Result<Option<TypestateService<Parseable>>> {
+        let Parseable {
+            event_tx,
+            mut temp_file,
+            original_prompt,
+        } = self.state;
+
+        let prompt = parse_prompt_file(temp_file.as_file_mut())?;
+        if prompt == original_prompt {
+            // If the prompt has not been changed, we should assume that the user is still editing it
+            // in a graphical text editor and we should wait for them to interact with Oatmeal before
+            // updating the prompt.
+            return Ok(Some(TypestateService {
+                state: Parseable {
+                    event_tx,
+                    temp_file,
+                    original_prompt,
+                },
+            }));
+        } else {
+            event_tx.send(Event::NewPrompt(prompt))?;
+            return Ok(None);
+        };
+    }
+
+    pub fn finish(self) -> Option<TypestateService<Parseable>> {
+        let event_tx = &self.state.event_tx.clone();
+        if let Err(err) = self.parse() {
+            let _ = send_error(event_tx, &err, "could not parse prompt file");
+        }
+        return None;
+    }
+
+    pub fn widget(&self) -> ratatui::widgets::Paragraph<'static> {
+        use ratatui::prelude::Alignment;
+        use ratatui::widgets::Block;
+        use ratatui::widgets::BorderType;
+        use ratatui::widgets::Borders;
+        use ratatui::widgets::Padding;
+        use ratatui::widgets::Paragraph;
+
+        return Paragraph::new("Waiting for editor, press Enter to continue.")
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_type(BorderType::Double)
+                    .padding(Padding::new(1, 1, 0, 0)),
+            )
+            .alignment(Alignment::Center);
+    }
+}
+
+const PROMPT_DELIMETER: &str =
+    "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~";
+const HINT_TEXT: &str =
+    "Write your prompt above the line and save to have it updated in Oatmeal\n\n";
+
+fn create_temp_file(prompt: &str, messages: &[Message]) -> Result<tempfile::NamedTempFile> {
+    let mut temp_file = tempfile::Builder::new()
+        .prefix("oatmeal-prompt")
+        .tempfile()?;
+
+    let reversed_messages = messages
+        .iter()
+        .rev()
+        .take(100) // TODO: Make this configurable
+        .map(|Message { author, text, .. }| format!("{author}:\n{text}\n"))
+        .collect::<Vec<_>>();
+
+    let prompt_with_newline = if prompt.is_empty() { "\n" } else { prompt };
+    let initial_content = prompt_with_newline
+        .lines()
+        .chain([PROMPT_DELIMETER, HINT_TEXT])
+        .chain(reversed_messages.iter().map(String::as_str))
+        .join("\n");
+
+    temp_file.write_all(initial_content.as_bytes())?;
+    return Ok(temp_file);
+}
+
+fn error_event(message: &str) -> Event {
+    return Event::EditPromptMessage(Message::new_with_type(
+        crate::domain::models::Author::Oatmeal,
+        crate::domain::models::MessageType::Error,
+        message,
+    ));
+}
+
+fn send_error(event_tx: &EventTx, error: &anyhow::Error, message: &str) -> Result<()> {
+    tracing::error!("{message}: {error}");
+    event_tx.send(error_event(message))?;
+    return Ok(());
+}
+
+fn get_editor() -> Result<crate::domain::models::EditorBox> {
+    use crate::configuration::{Config, ConfigKey};
+    use crate::domain::models::EditorName;
+    use crate::infrastructure::editors::EditorManager;
+
+    let editor_name = EditorName::parse(Config::get(ConfigKey::Editor)).unwrap();
+    let editor = EditorManager::get(editor_name.clone())?;
+
+    return Ok(editor);
+}
+
+async fn launch_editor(temp_file_path: &std::path::Path) -> Result<()> {
+    let editor = get_editor()?;
+    return editor.edit_prompt(temp_file_path).await;
+}
+
+fn parse_prompt_file(prompt_file: &mut std::fs::File) -> Result<String> {
+    prompt_file.rewind()?;
+
+    let reader = BufReader::new(prompt_file);
+    let prompt = reader
+        .lines()
+        .map_while(Result::ok)
+        .take_while(|line| return line != PROMPT_DELIMETER)
+        .join("\n");
+
+    return Ok(prompt);
+}

--- a/src/domain/services/edit_prompt_test.rs
+++ b/src/domain/services/edit_prompt_test.rs
@@ -1,0 +1,142 @@
+use tokio::sync::mpsc;
+
+use super::*;
+use crate::configuration::{Config, ConfigKey};
+use crate::domain::models::Event;
+use crate::domain::models::{Author, Message, MessageType};
+
+#[test]
+fn it_can_build_buildable() {
+    assert!(matches!(
+        ActiveService::build(),
+        TypestateService {
+            state: Buildable {}
+        }
+    ));
+}
+
+#[test]
+fn it_can_make_startable() {
+    let (tx, _rx) = mpsc::unbounded_channel::<Event>();
+    assert!(matches!(
+        ActiveService::build().event_tx(&tx),
+        TypestateService {
+            state: Startable { .. }
+        },
+    ));
+}
+
+#[test]
+fn it_can_create_temp_file() {
+    let (tx, _rx) = mpsc::unbounded_channel::<Event>();
+    let svc = ActiveService::build()
+        .event_tx(&tx)
+        .create_temp_file()
+        .unwrap();
+    let path = svc.state.temp_file.path();
+    assert!(std::fs::read_to_string(path).is_ok());
+}
+
+#[test]
+fn it_creates_tempfile_with_prompt() {
+    let (tx, _rx) = mpsc::unbounded_channel::<Event>();
+    let prompt = "a multiline
+    string";
+    let svc = ActiveService::build()
+        .event_tx(&tx)
+        .prompt(prompt)
+        .create_temp_file()
+        .unwrap();
+    let contents = std::fs::read_to_string(svc.state.temp_file.path()).unwrap();
+    assert!(contents.starts_with(prompt));
+}
+
+#[test]
+fn it_creates_tempfile_with_messages() {
+    let username = Config::get(ConfigKey::Username);
+    let model = Config::get(ConfigKey::Model);
+    Config::set(ConfigKey::Username, "bugs bunny");
+    Config::set(ConfigKey::Model, "chatgpt84");
+
+    let (tx, _rx) = mpsc::unbounded_channel::<Event>();
+    let messages = [
+        Message::new(Author::Model, "as an ai language model..."),
+        Message::new(Author::User, "what's up doc"),
+        Message::new_with_type(Author::Oatmeal, MessageType::Error, "oatmeal error"),
+    ];
+    let svc = ActiveService::build()
+        .event_tx(&tx)
+        .messages(&messages)
+        .create_temp_file()
+        .unwrap();
+    let contents = std::fs::read_to_string(svc.state.temp_file.path()).unwrap();
+    let expected_content_end = "\n\
+        Oatmeal:\n\
+        oatmeal error\n\
+        \n\
+        bugs bunny:\n\
+        what's up doc\n\
+        \n\
+        chatgpt84:\n\
+        as an ai language model...\n\
+    ";
+    assert!(contents.ends_with(expected_content_end));
+
+    Config::set(ConfigKey::Username, &username);
+    Config::set(ConfigKey::Model, &model);
+}
+
+#[test]
+fn it_always_adds_one_empty_line() {
+    let (tx, _rx) = mpsc::unbounded_channel::<Event>();
+    let svc = ActiveService::build()
+        .event_tx(&tx)
+        .create_temp_file()
+        .unwrap();
+    let contents = std::fs::read_to_string(svc.state.temp_file.path()).unwrap();
+    assert_eq!(
+        contents
+            .lines()
+            .map(|line| return line.is_empty())
+            .take(3)
+            .collect::<Vec<bool>>(),
+        vec![true, false, false]
+    );
+}
+
+#[test]
+fn it_can_parse_a_prompt_file() {
+    let (tx, mut rx) = mpsc::unbounded_channel::<Event>();
+    let mut svc = ActiveService::build()
+        .event_tx(&tx)
+        .create_temp_file()
+        .unwrap();
+
+    let contents = std::fs::read_to_string(svc.state.temp_file.path()).unwrap();
+    let prompt = "new prompt\n\
+        on multiple\n\
+        \n\
+        lines\n\
+    ";
+    let new_contents = format!("{prompt}{contents}");
+    svc.state.temp_file.rewind().unwrap();
+    svc.state
+        .temp_file
+        .write_all(new_contents.as_bytes())
+        .unwrap();
+
+    let svc = TypestateService {
+        state: Parseable {
+            event_tx: tx,
+            temp_file: svc.state.temp_file,
+            original_prompt: "".to_owned(),
+        },
+    };
+    let _svc = svc.parse().unwrap();
+    let msg = rx.blocking_recv().unwrap();
+    assert!(matches!(msg, Event::NewPrompt(_)));
+    let Event::NewPrompt(new_prompt) = msg else {
+        panic!();
+    };
+    assert_eq!(prompt, new_prompt);
+}

--- a/src/domain/services/events.rs
+++ b/src/domain/services/events.rs
@@ -100,6 +100,13 @@ impl EventsService {
                         return Some(Event::KeyboardCTRLO());
                     }
                     Input {
+                        key: Key::Char('e'),
+                        ctrl: true,
+                        ..
+                    } => {
+                        return Some(Event::KeyboardCTRLE());
+                    }
+                    Input {
                         key: Key::Char('r'),
                         ctrl: true,
                         ..

--- a/src/domain/services/mod.rs
+++ b/src/domain/services/mod.rs
@@ -4,6 +4,7 @@ mod bubble;
 mod bubble_list;
 pub mod clipboard;
 mod code_blocks;
+pub mod edit_prompt;
 pub mod events;
 mod scroll;
 mod sessions;


### PR DESCRIPTION
Hi,

I've made a bit of progress on this feature and I just wanted to get your opinion on whether it is useful enough to pursue and what you think of the code so far.

It is basically functional: When the user types /e or <C-e>, the current prompt is copied to a tempfile and $EDITOR is launched to edit it there. Once finished, the updated prompt is copied back into the text area.

It doesn't do anything special with oatmeal.nvim so you end up with a second nvim window within nvim, which isn't ideal. I'm pretty sure the fix is to work out what the correct command is to send to the nvim socket and do that instead of lauching a new process, but I'd like to see what you think of this before taking it any further.

There are some tests and documentation is lacking but hopefully it's clear enough.

All the best,
Peter