### PR TITLE
chore: Update anthropic sdk url

### DIFF
--- a/src/infrastructure/backends/claude.rs
+++ b/src/infrastructure/backends/claude.rs
@@ -140,7 +140,7 @@ impl Backend for Claude {
             "claude-2.0".to_string(),
         ];
         let res = reqwest::Client::new()
-            .get("https://raw.githubusercontent.com/anthropics/anthropic-sdk-typescript/main/src/resources/messages.ts")
+            .get("https://raw.githubusercontent.com/anthropics/anthropic-sdk-typescript/main/src/resources/messages/messages.ts")
             .send()
             .await;
 


### PR DESCRIPTION
Anthropic recently updated their Typescript sdk which moved their `messages.ts` file to `messages/messages.ts`: 

https://github.com/anthropics/anthropic-sdk-typescript/commit/7fd4830dae44ab66f6125728d4b18eeba8d58219#diff-f84d26bb589ee5d7b31552464184d35f41637fb2ed83bf945d937e4c8a9808dd

This results in oatmeal erroneously claiming that an claude model does not exist even though the user can still successfully query the model:
![image](https://github.com/user-attachments/assets/9b96ede0-cfc0-4e56-870f-4d6a917e3c26)